### PR TITLE
Fix 404 while searching

### DIFF
--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -80,6 +80,10 @@ class AttachMany extends Field
             return true;
         }
 
+        if(! isset($request->resource)) {
+            return true;
+        }
+
         return call_user_func([ $this->resourceClass, 'authorizedToViewAny'], $request)
             && $request->newResource()->authorizedToAttachAny($request, $this->resourceClass::newModel())
             && parent::authorize($request);

--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -81,7 +81,7 @@ class AttachMany extends Field
         }
 
         if(! isset($request->resource)) {
-            return true;
+            return false;
         }
 
         return call_user_func([ $this->resourceClass, 'authorizedToViewAny'], $request)


### PR DESCRIPTION
Search request doen't have resource property, so calling `$request->newResource()` in `src/AttachMany.php` line 84 which is defined in `nova/src/Http/Requests/InteractsWithResources.php` will abort at line 51 `abort_if(is_null($resource), 404)`