### PR TITLE
Support Nova Dependency Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dillingham/nova-attach-many",
+    "name": "demency/nova-attach-many",
     "description": "Attach Many Nova field",
     "keywords": [
         "laravel",

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+**NOTE** This is a fork of https://github.com/dillingham/nova-attach-many, but this package support Nova Dependency Container Package.
+
 # Nova Attach Many
 
 [![Latest Version on Github](https://img.shields.io/github/release/dillingham/nova-attach-many.svg?style=flat-square)](https://packagist.org/packages/dillingham/nova-attach-many)

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -32,6 +32,18 @@ class AttachController extends Controller
             ->where('component', 'nova-attach-many')
             ->where('attribute', $relationship)
             ->first();
+        
+        if (is_null($field)) {
+            $field = $resourceClass
+                ->availableFields($request)
+                ->where('component', 'nova-dependency-container')
+                ->map(function($component) {
+                    return $component->meta["fields"];
+                })->collapse()
+                ->where('component', 'nova-attach-many')
+                ->where('attribute', $relationship)
+                ->first();
+        }
 
         $query = $field->resourceClass::newModel();
 


### PR DESCRIPTION
This package doesn't support Nova Dependency Container and throw Exception on Controller because the AttachMany field is in a child element. So the first() on line 30 of AttachController returns null. I added some lines to fix it and now support the package.

Ref: Dependency Container Package.
https://github.com/epartment/nova-dependency-container

I change too the composer.json to use this solution via packagist in my project meanwhile this change is merged in this repo. Please rollback the change to back dillingham credit. and obviusly, remove the note added on README.md

Thanks dude, your package is awesome! 