### PR TITLE
Wrap around native BelongsToMany field

### DIFF
--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -2,6 +2,7 @@
 
 namespace NovaAttachMany\Http\Controllers;
 
+use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Resource;
 use Illuminate\Routing\Controller;
 use Laravel\Nova\Http\Requests\NovaRequest;
@@ -33,13 +34,17 @@ class AttachController extends Controller
             ->where('attribute', $relationship)
             ->first();
 
-        $query = $field->resourceClass::newModel();
-
-        return $field->resourceClass::relatableQuery($request, $query)->get()
+        return BelongsToMany::make(
+            null,
+            $relationship,
+            $field->resourceClass
+            )
+            ->buildAttachableQuery($request)
+            ->get()
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);
-            })->map(function($resource) {
+            })->map(function ($resource) {
                 return [
                     'display' => $resource->title(),
                     'value' => $resource->getKey(),

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -3,7 +3,6 @@
 namespace NovaAttachMany\Http\Controllers;
 
 use Laravel\Nova\Fields\BelongsToMany;
-use Laravel\Nova\Resource;
 use Illuminate\Routing\Controller;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
@@ -34,11 +33,7 @@ class AttachController extends Controller
             ->where('attribute', $relationship)
             ->first();
 
-        return BelongsToMany::make(
-            null,
-            $relationship,
-            $field->resourceClass
-            )
+        return BelongsToMany::make(null, $relationship, $field->resourceClass)
             ->buildAttachableQuery($request)
             ->get()
             ->mapInto($field->resourceClass)


### PR DESCRIPTION
Rather than accessing the target resource directly, we should wrap around the BelongsToMany field and use the `buildAttachableQuery` method this field provides. By using the `buildAttachableQuery` we then have access to scope filtering functionality as described here:

https://github.com/laravel/nova-issues/issues/241