### PR TITLE
Add ability to overrule the display name

### DIFF
--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -5,6 +5,7 @@ namespace NovaAttachMany;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Authorizable;
+use Laravel\Nova\Fields\FormatsRelatableDisplayValues;
 use NovaAttachMany\Rules\ArrayRules;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Fields\ResourceRelationshipGuesser;
@@ -12,6 +13,7 @@ use Laravel\Nova\Fields\ResourceRelationshipGuesser;
 class AttachMany extends Field
 {
     use Authorizable;
+    use FormatsRelatableDisplayValues;
 
     public $height = '300px';
 
@@ -26,6 +28,8 @@ class AttachMany extends Field
     public $showOnIndex = false;
 
     public $showOnDetail = false;
+
+    public $display;
 
     public $component = 'nova-attach-many';
 
@@ -87,6 +91,14 @@ class AttachMany extends Field
         return call_user_func([ $this->resourceClass, 'authorizedToViewAny'], $request)
             && $request->newResource()->authorizedToAttachAny($request, $this->resourceClass::newModel())
             && parent::authorize($request);
+    }
+
+    public function formatAssociatableResource(NovaRequest $request, $resource)
+    {
+        return array_filter([
+            'display' => $this->formatDisplayValue($resource),
+            'value' => $resource->getKey(),
+        ]);
     }
 
     public function height($height)

--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -5,10 +5,10 @@ namespace NovaAttachMany;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Authorizable;
-use Laravel\Nova\Fields\FormatsRelatableDisplayValues;
 use NovaAttachMany\Rules\ArrayRules;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Fields\ResourceRelationshipGuesser;
+use Laravel\Nova\Fields\FormatsRelatableDisplayValues;
 
 class AttachMany extends Field
 {

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -39,11 +39,8 @@ class AttachController extends Controller
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);
-            })->map(function($resource) {
-                return [
-                    'display' => $resource->title(),
-                    'value' => $resource->getKey(),
-                ];
+            })->map(function ($resource) use ($request, $field) {
+                return $field->formatAssociatableResource($request, $resource);
             })->sortBy('display')->values();
     }
 }


### PR DESCRIPTION
Allows you to overrule the display name like the `BelongsTo` field:

Example:
```
AttachMany::make('Threads')->display(function ($thread){
    return $thread->order.  ': ' . $thread->name;
}),
```