### PR TITLE
Call method on model when syncing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,31 @@ Here are a few customization options
 The attachable resources will be filtered by relatableQuery()
 So you can filter which resources are able to be attached
 
+### Being Notified of Changes
+You can add a method to the model to be notified of the changes that have happened:
+
+```php
+public function permissionsSynced(array $changes)
+{
+    $changes['attached']; // An array of IDs of attached models
+    $changes['detached']; // An array of IDs of detached models
+    $changes['updated']; // An array of IDs of updated models
+}
+```
+
+The method must be a camel cased version of the attribute name, followed by `Synced`. For example:
+
+```php
+public function fields(Request $request)
+{
+    return [
+        AttachMany::make('Related Authors'),
+    ];
+}
+```
+
+would require a method on the model called `relatedAuthorsSynced()`.
+
 ### Authorization
 This field also respects policies: ie Role / Permission
 - RolePolicy: attachAnyPermission($user, $role)

--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -2,6 +2,7 @@
 
 namespace NovaAttachMany;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Authorizable;
@@ -44,9 +45,15 @@ class AttachMany extends Field
         $this->fillUsing(function($request, $model, $attribute, $requestAttribute) use($resource) {
             if(is_subclass_of($model, 'Illuminate\Database\Eloquent\Model')) {
                 $model::saved(function($model) use($attribute, $request) {
-                    $model->$attribute()->sync(
+                    $changes = $model->$attribute()->sync(
                         json_decode($request->$attribute, true)
                     );
+
+                    $method = Str::camel($attribute) . 'Synced';
+                    
+                    if (method_exists($model, $method)) {
+                        $model->{$method}($changes);
+                    }
                 });
 
                 unset($request->$attribute);


### PR DESCRIPTION
Because of the issues I was having in #48 and the issue @ericdiviney was having in #16, this PR adds a call to a method on the underlying model class, if it exists.

The Laravel `->sync()` method returns an array of changes as can be seen here: https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php#L90.

This PR takes the attribute name, converts to camelCase and adds `Synced` to the end, and attempts to call that method if it exists on the model.

This is useful in the following circumstance (as outlined in #48).

If I have an `Author` model:

```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Relations\BelongsToMany;

class Author extends Model
{
    public function relatedAuthors(): BelongsToMany
    {
        return $this->belongsToMany(self::class, 'related_authors', 'author_id', 'related_author_id');
    }
}
```

I can now add a method `relatedAuthorsSynced()` to the model which can accept the list of changes that have happened:

```php
public function relatedAuthorsSynced(array $changes): void
{
    info('The following IDs have been attached:');
    info($changes['attached']);

    info('The following IDs have been detached:');
    info($changes['detached']);

    info('The following IDs have been updated:');
    info($changes['updated']);
}
```

Using this information I could now sync the inverse side really easily. In the case of #16 the model could either fire a new event to be observed, or the code from the observer could be brought into the model.

Users are free to ignore the method if they want the existing behaviour and the line referenced in #48 (https://github.com/dillingham/nova-attach-many/blob/master/src/AttachMany.php#L46) can continue working as it is, ensuring that the model has been saved successfully before attempting the sync.

I've also updated the README to document the change.