### PR TITLE
applies array_filter to submitted values to remove erroneous values

### DIFF
--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -44,9 +44,16 @@ class AttachMany extends Field
         $this->fillUsing(function($request, $model, $attribute, $requestAttribute) use($resource) {
             if(is_subclass_of($model, 'Illuminate\Database\Eloquent\Model')) {
                 $model::saved(function($model) use($attribute, $request) {
-                    $model->$attribute()->sync(
-                        json_decode($request->$attribute, true)
-                    );
+
+                    // fetch the submitted values
+                    $values = json_decode($request->$attribute, true);
+
+                    // remove `null` values that may be submitted
+                    $filtered_values = array_filter($values);
+
+                    // sync
+                    $model->$attribute()->sync($filtered_values);
+
                 });
 
                 unset($request->$attribute);


### PR DESCRIPTION
In some cases while testing, null values were being submitted (probably an error) and I don't believe null values should be applicable to sync. This patch just filters out null values that were submitted.