### PR TITLE
Support other key names instead of assuming `id`

### DIFF
--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -44,9 +44,16 @@ class AttachMany extends Field
         $this->fillUsing(function($request, $model, $attribute, $requestAttribute) use($resource) {
             if(is_subclass_of($model, 'Illuminate\Database\Eloquent\Model')) {
                 $model::saved(function($model) use($attribute, $request) {
-                    $model->$attribute()->sync(
-                        json_decode($request->$attribute, true)
-                    );
+
+                    // fetch the submitted values
+                    $values = json_decode($request->$attribute, true);
+
+                    // remove `null` values that may be submitted
+                    $filtered_values = array_filter($values);
+
+                    // sync
+                    $model->$attribute()->sync($filtered_values);
+
                 });
 
                 unset($request->$attribute);

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -17,8 +17,20 @@ class AttachController extends Controller
 
     public function edit(NovaRequest $request, $parent, $parentId, $relationship)
     {
+        // lookup the resource
+        $foundResource = $request->findResourceOrFail();
+
+        // if the $relationship() method exists, we will use that to
+        // determine the keyName
+        if(method_exists($foundResource->model(), $relationship)){
+            $keyName = $foundResource->model()->{$relationship}()->getModel()->getKeyName();
+            // otherwise default to an assumed keyName of `id`
+        }else{
+            $keyName = 'id';
+        }
+
         return [
-            'selected' => $request->findResourceOrFail()->model()->{$relationship}->pluck('id'),
+            'selected' => $foundResource->model()->{$relationship}->pluck($keyName),
             'available' => $this->getAvailableResources($request, $relationship),
         ];
     }


### PR DESCRIPTION
If your model uses any other key name aside from id, this package fails. This patch will lookup the keyname from the related model or fail back to using `id`.