### PR TITLE
Add custom key to manage not-standard belongs2many

### DIFF
--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -31,6 +31,8 @@ class AttachMany extends Field
 
     public $showSubtitle = false;
 
+    public $customKey;
+
     public $showOnIndex = false;
 
     public $showOnDetail = false;
@@ -127,7 +129,7 @@ class AttachMany extends Field
     {
         $item = [
             'display' => $this->formatDisplayValue($resource),
-            'value' => $resource->getKey(),
+            'value' => $this->customKey ? $resource->{$this->customKey} : $resource->getKey(),
         ];
 
         if($this->showSubtitle) {
@@ -182,6 +184,13 @@ class AttachMany extends Field
     public function showSubtitle($showSubtitle=true)
     {
         $this->showSubtitle = $showSubtitle;
+
+        return $this;
+    }
+
+    public function withCustomKey($customKey)
+    {
+        $this->customKey = $customKey;
 
         return $this;
     }


### PR DESCRIPTION
I've got this scenario.

Two models:

- Rule
- Persona

A `Rule` has a belongsToMany relationship with `Persona`:

```php
public function personas()
{
  return $this->belongsToMany(Persona::class, 'feature_rule_personas', 'rule_id', 'persona_code', 'id', 'code');
}
```

I would like to have in the pivot table not the Rule ->getKey but a custom key, in this case the `code` column: Laravel will allow me to do this using some extra parameter in belongsToMany.

Without this PR, plugin will use `sync` method using `id` column and not the right `code` column, inserting wrong data in database.

Because detecting automatically the "foreign key" in the pivot table is so unconfortable, this PR add a new `customKey` method in order to overwrite standard behavior:

```php
AttachMany::make('Personas', 'personas', Persona::class)
   ->withCustomKey('code'),
```


