### PR TITLE
Added 'orderBy' option

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -85,8 +85,9 @@ export default {
         retrieveData(keepSelected=false) {
             let baseUrl = '/nova-vendor/nova-attach-many/';
 
+            let orderByStr = this.field.orderBy ? '?orderby=' + this.field.orderBy.join(',') : ''
             if(this.resourceId) {
-                Nova.request(baseUrl + this.resourceName + '/' + this.resourceId + '/attachable/' + this.field.attribute)
+                Nova.request(baseUrl + this.resourceName + '/' + this.resourceId + '/attachable/' + this.field.attribute + orderByStr)
                     .then((data) => {
                         if(keepSelected) {
                             this.selected = _.intersection(this.selected, _.map(data.data.available, 'value'));
@@ -98,7 +99,7 @@ export default {
                     });
             }
             else {
-                Nova.request(baseUrl + this.resourceName + '/attachable/' + this.field.attribute)
+                Nova.request(baseUrl + this.resourceName + '/attachable/' + this.field.attribute + orderByStr)
                     .then((data) => {
                         this.available = data.data.available || [];
                         this.loading = false;

--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -19,6 +19,8 @@ class AttachMany extends Field
 
     public $height = '300px';
 
+    public $orderBy = [];
+
     public $fullWidth = false;
 
     public $showToolbar = true;
@@ -57,7 +59,7 @@ class AttachMany extends Field
 
                     // fetch the submitted values
                     $values = json_decode(request()->input($attribute), true);
-                    
+
                     // if $values is null make it an empty array instead
                     if (is_null($values)) {
                         $values = [];
@@ -100,6 +102,7 @@ class AttachMany extends Field
     {
         $this->withMeta([
             'height' => $this->height,
+            'orderBy' => $this->orderBy,
             'fullWidth' => $this->fullWidth,
             'showCounts' => $this->showCounts,
             'showPreview' => $this->showPreview,
@@ -145,6 +148,13 @@ class AttachMany extends Field
     public function height($height)
     {
         $this->height = $height;
+
+        return $this;
+    }
+
+    public function orderBy($orderBy)
+    {
+        $this->orderBy = $orderBy;
 
         return $this;
     }


### PR DESCRIPTION
Hi Brian,

I'm pretty new when it comes to creating pull requests, and I don't thoroughly understand your (and Nova's) codebase, but I hope this Pull Request will at least give you a good idea of a way to implement an "orderBy" option with which the user can specify the columns by which to order the listing by.

Just as an example as to how this would look in a Resource, which uses your AttachMany field:
```
AttachMany::make('People')
    ->showRefresh()
    ->orderBy(['last_name', 'first_name']),
```
Please let me know if there's anything else I can do from my end.

Thank you for your very useful & helpful tool!