### PR TITLE
Fix parameters to relatableQuery

### DIFF
--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -41,9 +41,10 @@ class AttachController extends Controller
             ->where('attribute', $relationship)
             ->first();
 
-        $query = $field->resourceClass::newModel()->newQuery();
+        $model = $field->resourceClass::newModel();
+        $query = $model->newQuery();
 
-        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query, $field)->get()
+        return forward_static_call($this->associatableQueryCallable($request, $model), $request, $query, $field)->get()
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -41,9 +41,9 @@ class AttachController extends Controller
             ->where('attribute', $relationship)
             ->first();
 
-        $query = $field->resourceClass::newModel();
+        $query = $field->resourceClass::newModel()->newQuery();
 
-        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query)->get()
+        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query, $field)->get()
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);


### PR DESCRIPTION
[According to the docs](https://nova.laravel.com/docs/3.0/resources/authorization.html#dynamic-relatable-methods), the relatableQuery method should receive a Builder object instead of a Model. 
Also it allows for the Field object to be passed as the third argument.

This change follows that signature in the `AttachController`.