### PR TITLE
[bugfix]: forward_static_call returning null

### DIFF
--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -43,7 +43,7 @@ class AttachController extends Controller
 
         $query = $field->resourceClass::newModel();
 
-        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query)->get()
+        return (forward_static_call($this->associatableQueryCallable($request, $query), $request, $query) ?? $query)->get()
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);


### PR DESCRIPTION
This means we don't assume relateableQuery() (or other) returns the query eg.

```
    public static function relatableQuery(NovaRequest $request, $query)
    {
        $query->whereEnabled();
    }
```