### PR TITLE
Pass $field param when getting available resources

### DIFF
--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -43,7 +43,7 @@ class AttachController extends Controller
 
         $query = $field->resourceClass::newModel();
 
-        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query)->get()
+        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query, $field)->get()
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);


### PR DESCRIPTION
The original AttachController did not pass the 3rd `$field` param to Dynamic Relatable Methods

See: https://nova.laravel.com/docs/3.0/resources/authorization.html#dynamic-relatable-methods