### PR TITLE
Do not use root namespace alias for Route

### DIFF
--- a/src/Providers/FieldServiceProvider.php
+++ b/src/Providers/FieldServiceProvider.php
@@ -4,6 +4,7 @@ namespace NovaAttachMany\Providers;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class FieldServiceProvider extends ServiceProvider
@@ -20,7 +21,7 @@ class FieldServiceProvider extends ServiceProvider
         });
 
         $this->app->booted(function () {
-            \Route::middleware(['nova'])
+            Route::middleware(['nova'])
                 ->prefix('nova-vendor/nova-attach-many')
                 ->group(__DIR__.'/../../routes/api.php');
         });


### PR DESCRIPTION
It's optional and can be disabled on any Laravel application