### PR TITLE
Too few arguments to function relatableModel Query

### DIFF
--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -43,7 +43,7 @@ class AttachController extends Controller
 
         $query = $field->resourceClass::newModel();
 
-        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query)->get()
+        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query, $field)->get()
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);


### PR DESCRIPTION
#98
Too few arguments to function App\Nova\User::relatableTeams(), 2 passed and exactly 3 expected
`public static function relatableTeams(NovaRequest $request, $query, $field)`