### PR TITLE
Use relatedKey instead of getKey in order to manage not-standard belongsTomany

### DIFF
--- a/src/AttachMany.php
+++ b/src/AttachMany.php
@@ -128,11 +128,11 @@ class AttachMany extends Field
             && parent::authorize($request);
     }
 
-    public function formatAssociatableResource(NovaRequest $request, $resource)
+    public function formatAssociatableResource(NovaRequest $request, $resource, $parentModel, $relationship)
     {
         $item = [
             'display' => $this->formatDisplayValue($resource),
-            'value' => $resource->getKey(),
+            'value' => $resource->{$parentModel->$relationship()->getRelatedKeyName()},
         ];
 
         if($this->showSubtitle) {

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -23,7 +23,7 @@ class AttachController extends Controller
             abort(500, class_basename($foundResource->model()) . " is missing relationship: $relationship");
         }
 
-        $keyName = $foundResource->model()->{$relationship}()->getModel()->getKeyName();
+        $keyName = $foundResource->model()->{$relationship}()->getRelatedKeyName();
 
         return [
             'selected' => $foundResource->model()->{$relationship}->pluck($keyName),

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -47,8 +47,8 @@ class AttachController extends Controller
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);
-            })->map(function ($resource) use ($request, $field) {
-                return $field->formatAssociatableResource($request, $resource);
+            })->map(function ($resource) use ($request, $field, $resourceClass, $relationship) {
+                return $field->formatAssociatableResource($request, $resource, $resourceClass->newModel(), $relationship);
             })->values();
     }
 


### PR DESCRIPTION
Use relatedKey instead of getKey in order to manage not-standard belongsTomany