### PR TITLE
[Nova 4] duplicate use declaration causes fatal error

### DIFF
--- a/src/Providers/FieldServiceProvider.php
+++ b/src/Providers/FieldServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace NovaAttachMany\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
 use Illuminate\Support\Facades\Route;


### PR DESCRIPTION
When using the dev-master that works on Nova 4, duplicate `use Illuminate\Support\Facades\Route;` causes fatal error.

Please merge and please tag a new release : )