### PR TITLE
restores Tailwind styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@vue/compiler-sfc": "^3.2.22",
         "laravel-mix": "^6.0.41",
         "postcss": "^8.3.11",
+        "tailwindcss": "^3.1.6",
         "vue-loader": "^16.8.3"
     },
     "dependencies": {}

--- a/resources/css/field.css
+++ b/resources/css/field.css
@@ -1,0 +1,5 @@
+/* Nova Card CSS */
+
+/* Nova Field CSS */
+@tailwind components;
+@tailwind utilities;

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -1,5 +1,5 @@
 <template>
-    <DefaultField :field="currentField" :full-width-content="currentField.fullWidth" :show-help-text="false">
+    <DefaultField :field="currentField" :full-width-content="currentField.fullWidth" :show-help-text="false" class="nova-attach-many">
         <template #field :class="{'border-danger border': hasErrors}">
             <div class="attach-many-container" :class="{'border-danger border': hasErrors}">
                 <div v-if="currentField.showToolbar" class="flex items-center border border-b-0 border-gray-100 dark:border-gray-700">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    content: [
+      "./resources/**/*.blade.php",
+      "./resources/**/*.js",
+      './resources/js/**/*.vue',
+    ],
+    theme: {
+      extend: {},
+    },
+    plugins: [],
+    important: '.nova-attach-many'
+  }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -6,4 +6,7 @@ mix
     .setPublicPath('dist')
     .js('resources/js/field.js', 'js')
     .vue({ version: 3 })
+    .postCss("resources/css/field.css", "css", [
+        require("tailwindcss"),
+    ])    
     .nova("dillingham/nova-attach-many")


### PR DESCRIPTION
Something changed in Nova 4 that breaks a lot of Tailwind classes. Basically, any class that is not used somewhere in Nova v4 won't be available inside 3rd party fields, cards, tools, etc.

It's explained in https://github.com/laravel/nova-issues/issues/4061#issuecomment-1108865028.

Fixing this involves adding tailwind to the package and using a way of "scoping" the field with a custom class.

Jess Archer's tweet here helped with the solution: https://twitter.com/jessarchercodes/status/1515139491794599939?

I've made the changes below. But for some reason I am having difficulty building the dist files because of the way you link to `laravel-nova` inside `mix.js`

You should be able to build the dist files and then test that the Tailwind styles are back to working like they were before.

Cheers!